### PR TITLE
Adds Prest::Response wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,7 @@
 ## [0.1.0] - 2022-07-20
 
 - Initial release
+
+## [0.1.1] - 2022-07-22
+
+- Wraps endpoints response in a `Prest::Response` object for easier access to the response data 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    prest (0.1.1)
+    prest (0.1.2)
       httparty (~> 0.20.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/f81b2e00be4d8eaa5e81/maintainability)](https://codeclimate.com/github/gogrow-dev/prest/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/f81b2e00be4d8eaa5e81/test_coverage)](https://codeclimate.com/github/gogrow-dev/prest/test_coverage)
 
-Programmaticcally communicate with any REST API.
+Programmatically communicate with any REST API.
 
 ## Installation
 
@@ -52,6 +52,21 @@ Prest::Client.new('https://example.com/api', { headers: { 'Authorization' => 'Be
 Prest::Client.new('https://example.com/api', { headers: { 'Authorization' => 'Bearer Token xxxyyyzzz' } })
              .users
              .post(body: { username: 'juan-apa' })
+```
+
+### Accessing the response
+
+```ruby
+response = Prest::Client.new('https://example.com/api').users.get
+
+response[:users] # is equivalent to response.body[:users]
+# You can access the body directly from the response object
+
+response.successful? # is equivalent to response.status is between 200-299
+
+response.status # returns the status code of the response
+response.headers # returns the headers of the response
+response.body # returns the body of the response
 ```
 
 ### Rails service-like approach

--- a/lib/prest.rb
+++ b/lib/prest.rb
@@ -2,6 +2,7 @@
 
 require 'httparty'
 require_relative 'prest/version'
+require_relative 'prest/response'
 
 module Prest
   class Error < StandardError; end
@@ -34,7 +35,10 @@ module Prest
     private
 
     def execute_query(http_method, body: {})
-      ::HTTParty.send(http_method, build_url, headers: headers, body: body)
+      res = ::HTTParty.send(http_method, build_url, headers: headers, body: body)
+      ::Prest::Response.new(res.code, res.parsed_response, res.headers)
+    rescue ::HTTParty::ResponseError => e
+      raise Error, e.message
     end
 
     def chain_fragment(fragment_name, *args, **kwargs)

--- a/lib/prest/response.rb
+++ b/lib/prest/response.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Prest
+  # Main wrapper class for Prest Response.
+  class Response
+    extend ::Forwardable
+
+    def_delegator :@body, :[]
+
+    attr_reader :status, :body, :headers
+
+    def initialize(status, body, headers)
+      @status = status
+      @body = body
+      @headers = headers
+    end
+
+    def successful?
+      @status.between?(100, 399)
+    end
+  end
+end

--- a/lib/prest/version.rb
+++ b/lib/prest/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Prest
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ SimpleCov.start do
 end
 
 require 'prest'
+Dir['./spec/support/**/*.rb'].sort.each { |f| require f }
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/spec/support/shared/allows_access_to_response_data.rb
+++ b/spec/support/shared/allows_access_to_response_data.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'forwards methods to httparty\'s response' do
+  it 'allows access to the status' do
+    expect(subject.status).to eq(code)
+  end
+
+  it 'allows access to the body' do
+    expect(subject.body).to eq(parsed_response)
+  end
+
+  it 'allows access to the headers' do
+    expect(subject.headers).to eq(headers)
+  end
+
+  it 'allows access direct access the parsed response data' do
+    expect(subject[:key]).to eq('value')
+  end
+end

--- a/spec/support/shared/returns_a_correct_response.rb
+++ b/spec/support/shared/returns_a_correct_response.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'returns a correct response' do
+  it 'returns a Prest::Response' do
+    expect(subject).to be_a(Prest::Response)
+  end
+
+  it 'returns a successful response' do
+    expect(subject.successful?).to eq(true)
+  end
+
+  context 'when the response is not successful with error code 400s' do
+    let!(:code) { 400 }
+
+    it 'returns a Prest::Response' do
+      expect(subject).to be_a(Prest::Response)
+    end
+
+    it 'returns a unsuccessful response' do
+      expect(subject.successful?).to eq(false)
+    end
+  end
+
+  context 'when the response is not successful with error code 500s' do
+    let!(:code) { 500 }
+
+    it 'returns a Prest::Response' do
+      expect(subject).to be_a(Prest::Response)
+    end
+
+    it 'returns a unsuccessful response' do
+      expect(subject.successful?).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
Wraps the `HTTParty` response in a `Prest::Response` object that facilitates the access to the response data:

```ruby
response = Prest::Client.new('https://example.com/api').users.get

response[:users] # is equivalent to response.body[:users]
# You can access the body directly from the response object

response.successful? # is equivalent to response.status is between 200-299

response.status # returns the status code of the response
response.headers # returns the headers of the response
response.body # returns the body of the response
```