### PR TITLE
Change dash and underscore behavior

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    prest (0.1.0)
+    prest (0.1.1)
       httparty (~> 0.20.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Prest::Client.new('https://example.com/api').users(name: 'Juan', created_at: '20
 Prest::Client.new('https://example.com/api').users(2).pulls(1).comments.get
 # This translates to making a GET https://example.com/api/users/2/pulls/1/comments
 
+# To make requests to url which have a dash in it, use a double __
+Prest::Client.new('https://example.com/api').job__posts(1).get
+# This translates to making a GET https://example.com/api/job-posts/1
+
 # To pass headers to the request, pass them to the client constructor
 Prest::Client.new('https://example.com/api', { headers: { 'Authorization' => 'Bearer Token xxxyyyzzz' } })
              .users

--- a/lib/prest.rb
+++ b/lib/prest.rb
@@ -41,7 +41,7 @@ module Prest
       arguments = args.join('/')
       parsed_args = arguments.empty? ? '' : "#{arguments}/"
       @query_params.merge!(kwargs)
-      @fragments << "#{fragment_name.tr("_", "-")}/#{parsed_args}"
+      @fragments << "#{fragment_name.gsub("__", "-")}/#{parsed_args}"
     end
 
     def headers

--- a/lib/prest/version.rb
+++ b/lib/prest/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Prest
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end

--- a/spec/prest/client_spec.rb
+++ b/spec/prest/client_spec.rb
@@ -29,7 +29,15 @@ RSpec.describe Prest::Client do
     context 'when fragment contains an underscore' do
       subject { client.fragment_name }
 
-      it 'replaces underscores with hyphens' do
+      it 'creates a url with underscores' do
+        expect { subject }.to change { client.fragments }.to(['fragment_name/'])
+      end
+    end
+
+    context 'when fragment contains two consecutive underscores' do
+      subject { client.fragment__name }
+
+      it 'replaces them with hyphens' do
         expect { subject }.to change { client.fragments }.to(['fragment-name/'])
       end
     end
@@ -40,7 +48,7 @@ RSpec.describe Prest::Client do
 
       it 'adds the param to url' do
         subject
-        expect(client.fragments).to eq(["fragment-name/#{param}/", 'fragment/'])
+        expect(client.fragments).to eq(["fragment_name/#{param}/", 'fragment/'])
       end
     end
 
@@ -50,7 +58,7 @@ RSpec.describe Prest::Client do
 
       it 'does not add the param to the fragments' do
         subject
-        expect(client.fragments).to eq(['fragment-name/', 'fragment/'])
+        expect(client.fragments).to eq(['fragment_name/', 'fragment/'])
       end
 
       it 'adds the param to the query_params' do
@@ -90,7 +98,7 @@ RSpec.describe Prest::Client do
         subject { client.fragment_name(param: 'value').__send__(http_method) }
 
         it "calls HTTParty\##{http_method} with correct params" do
-          expect(HTTParty).to receive(http_method).with("#{base_uri}/fragment-name/?param=value", body: {},
+          expect(HTTParty).to receive(http_method).with("#{base_uri}/fragment_name/?param=value", body: {},
                                                                                                   headers: {})
           subject
         end


### PR DESCRIPTION
This PR changes the behavior of how underscores and dashes in the url are built.
- Use `__` to build a route with a dash
- Use `_` to build a route with an underscore 