### PR TITLE
Fix method chaining with params

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    prest (0.1.4)
+    prest (0.1.5)
       httparty (~> 0.20.0)
 
 GEM

--- a/lib/prest.rb
+++ b/lib/prest.rb
@@ -54,9 +54,9 @@ module Prest
 
     def chain_fragment(fragment_name, *args, **kwargs)
       arguments = args.join('/')
-      parsed_args = arguments.empty? ? '' : "#{arguments}/"
+      parsed_args = arguments.empty? ? '' : "/#{arguments}"
       @query_params.merge!(kwargs)
-      @fragments << "#{fragment_name.gsub("__", "-")}/#{parsed_args}"
+      @fragments << "#{fragment_name.gsub("__", "-")}#{parsed_args}"
     end
 
     def headers

--- a/lib/prest/version.rb
+++ b/lib/prest/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Prest
-  VERSION = '0.1.4'
+  VERSION = '0.1.5'
 end

--- a/spec/prest/client_spec.rb
+++ b/spec/prest/client_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Prest do
 
     it 'adds each fragment to the fragments array' do
       subject
-      expect(client.fragments).to eq(%w[method1/ method2/ method3/])
+      expect(client.fragments).to eq(%w[method1 method2 method3])
     end
 
     it 'returns an instance of Prest::Client' do
@@ -34,10 +34,10 @@ RSpec.describe Prest do
     end
 
     context 'when fragment contains an underscore' do
-      subject { client.fragment_name }
+      subject { client.fragment_name.example }
 
       it 'creates a url with underscores' do
-        expect { subject }.to change { client.fragments }.to(['fragment_name/'])
+        expect { subject }.to change { client.fragments }.to(%w[fragment_name example])
       end
     end
 
@@ -45,7 +45,7 @@ RSpec.describe Prest do
       subject { client.fragment__name }
 
       it 'replaces them with hyphens' do
-        expect { subject }.to change { client.fragments }.to(['fragment-name/'])
+        expect { subject }.to change { client.fragments }.to(['fragment-name'])
       end
     end
 
@@ -55,7 +55,7 @@ RSpec.describe Prest do
 
       it 'adds the param to url' do
         subject
-        expect(client.fragments).to eq(["fragment_name/#{param}/", 'fragment/'])
+        expect(client.fragments).to eq(["fragment_name/#{param}", 'fragment'])
       end
     end
 
@@ -65,7 +65,7 @@ RSpec.describe Prest do
 
       it 'does not add the param to the fragments' do
         subject
-        expect(client.fragments).to eq(['fragment_name/', 'fragment/'])
+        expect(client.fragments).to eq(%w[fragment_name fragment])
       end
 
       it 'adds the param to the query_params' do
@@ -109,8 +109,8 @@ RSpec.describe Prest do
         subject { client.fragment_name(param: 'value').__send__(http_method) }
 
         it "calls HTTParty\##{http_method} with correct params" do
-          expect(HTTParty).to receive(http_method).with("#{base_uri}/fragment_name/?param=value", body: {},
-                                                                                                  headers: {})
+          expect(HTTParty).to receive(http_method).with("#{base_uri}/fragment_name?param=value", body: {},
+                                                                                                 headers: {})
           subject
         end
 

--- a/spec/prest/service_spec.rb
+++ b/spec/prest/service_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Prest::Service' do
     end
 
     it 'returns a new valid instance of Prest::Client' do
-      expect(subject.fragments).to eq(%w[fragment1/ fragment2/ fragment3/])
+      expect(subject.fragments).to eq(%w[fragment1 fragment2 fragment3])
       expect(subject.base_uri).to eq(base_uri)
       expect(subject.options).to eq({
                                       headers: {
@@ -64,7 +64,7 @@ RSpec.describe 'Prest::Service' do
     end
 
     it 'returns a new valid instance of Prest::Client' do
-      expect(subject.fragments).to eq(%w[fragment1/ fragment2/ fragment3/])
+      expect(subject.fragments).to eq(%w[fragment1 fragment2 fragment3])
       expect(subject.base_uri).to eq(base_uri)
       expect(subject.options).to eq({
                                       headers: {


### PR DESCRIPTION
method chaining with params was not working properly e.g.

```ruby
Prest::Client.users(1).pulls # produces
https://api.example.com/users/1//pulls
```

Now it does the following:
```ruby
Prest::Client.users(1).pulls # produces
https://api.example.com/users/1/pulls
```