### PR TITLE
Add `__query_params` kwarg to fragments chaining

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    prest (0.1.7)
+    prest (0.1.8)
       httparty (~> 0.20.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -56,11 +56,12 @@ Prest::Client.new('https://example.com/api', { headers: { 'Authorization' => 'Be
 
 ### Using raw/custom/special query parameters
 
-Because ruby does not accept duplicate keyword arguments on method calls, you can not do the following:
+In ruby, duplicate keyword arguments on method calls are not accepted, so you **can not** do the following:
 
 ```ruby
-# GET https://example.com/api/example?key=1&key2
 Prest::Client.new('https://example.com/api').example(key: 1, key: 2).get
+# `key: 1` is overriden by `key: 2`;
+# produces: GET https://example.com/api/one/two?key=2
 ```
 
 Because of this and other cases where formatting is very strict/unusual, you can pass a string which will not be formatted to the query parameters. To do this, use the following:
@@ -73,6 +74,27 @@ Prest::Client.new('https://example.com/api')
 ```
 
 The string passed to the keyword argument `__query_params` will not be formatted, and passed as is.
+
+> **Warning**
+> `__query_params` is the only keyword argument that can be repeated across method calls:
+
+```ruby
+Prest::Client.new('https://example.com/api')
+             .one(key: '1')
+             .two(key: '2')
+             .get
+# Produces: GET https://example.com/api/one/two?key=2
+```
+
+However using `__query_params`:
+
+```ruby
+Prest::Client.new('https://example.com/api')
+             .one(__query_params: 'key=1')
+             .two(__query_params: 'key=2')
+             .get
+#Produces: GET https://example.com/api/one/two?key=1&key=2
+```
 
 ### Automatically adding the json headers
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,26 @@ Prest::Client.new('https://example.com/api', { headers: { 'Authorization' => 'Be
              .post(body: { username: 'juan-apa' })
 ```
 
+### Using raw/custom/special query parameters
+
+Because ruby does not accept duplicate keyword arguments on method calls, you can not do the following:
+
+```ruby
+# GET https://example.com/api/example?key=1&key2
+Prest::Client.new('https://example.com/api').example(key: 1, key: 2).get
+```
+
+Because of this and other cases where formatting is very strict/unusual, you can pass a string which will not be formatted to the query parameters. To do this, use the following:
+
+```ruby
+# GET https://example.com/api/example?key=1&key2&other=value
+Prest::Client.new('https://example.com/api')
+             .example(__query_params: 'key=1&key=2', other: 'value')
+             .get
+```
+
+The string passed to the keyword argument `__query_params` will not be formatted, and passed as is.
+
 ### Automatically adding the json headers
 
 Because some API's need a `Content-Type: application/json` and/or `Accept: application/json` headers, there's a built in option that can be passed to the client to add those for you:

--- a/lib/prest/client.rb
+++ b/lib/prest/client.rb
@@ -57,7 +57,9 @@ module Prest
       arguments = args.join('/')
       parsed_args = arguments.empty? ? '' : "/#{arguments}"
       extract_raw_query_params!(kwargs)
-      @query_params.merge!(kwargs.except(:__query_params))
+      dup_kwargs = kwargs.dup
+      dup_kwargs.delete(:__query_params)
+      @query_params.merge!(dup_kwargs)
       @fragments << "#{fragment_name.gsub("__", "-")}#{parsed_args}"
     end
 
@@ -85,12 +87,11 @@ module Prest
     def extract_raw_query_params!(kwargs)
       return unless kwargs.key?(:__query_params)
 
-      raw_query_params = if @query_params[:__query_params].is_a?(::Array)
-                           @query_params[:__query_params] += array_wrap(kwargs[:__query_params])
-                         else
-                           array_wrap(kwargs[:__query_params])
-                         end
-      @query_params[:__query_params] = raw_query_params
+      @query_params[:__query_params] = if @query_params[:__query_params].is_a?(::Array)
+                                         @query_params[:__query_params] + array_wrap(kwargs[:__query_params])
+                                       else
+                                         array_wrap(kwargs[:__query_params])
+                                       end
     end
   end
 end

--- a/lib/prest/version.rb
+++ b/lib/prest/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Prest
-  VERSION = '0.1.7'
+  VERSION = '0.1.8'
 end

--- a/spec/prest/client_spec.rb
+++ b/spec/prest/client_spec.rb
@@ -72,6 +72,16 @@ RSpec.describe Prest do
         subject
         expect(client.query_params).to eq(param: param)
       end
+
+      context 'when the __query_param key passed as a keyword argument' do
+        let(:param) { 'param[]=1&param[]=2' }
+        subject { client.fragment_name(__query_params: param).fragment }
+
+        it 'adds the param to the query_params' do
+          subject
+          expect(client.query_params).to eq(__query_params: [param])
+        end
+      end
     end
   end
 
@@ -121,11 +131,12 @@ RSpec.describe Prest do
       end
 
       context 'when query params are passed' do
-        subject { client.fragment_name(param: 'value').__send__(http_method) }
+        subject { client.fragment_name(param: 'value', __query_params: 'key=1&key=2').__send__(http_method) }
 
         it "calls HTTParty\##{http_method} with correct params" do
-          expect(HTTParty).to receive(http_method).with("#{base_uri}/fragment_name?param=value", body: {},
-                                                                                                 headers: {})
+          expect(HTTParty).to receive(http_method).with("#{base_uri}/fragment_name?key=1&key=2&param=value",
+                                                        body: {},
+                                                        headers: {})
           subject
         end
 


### PR DESCRIPTION
add `__query_params` kwarg in fragment chaining to pass raw query parameters to the request.